### PR TITLE
remove start at creation

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ var util = require('util'),
 var Watchdog = function(expires) {
   this.expires = expires || 2000;
   this._timeout = null;
-  this.kick();
 };
 
 util.inherits(Watchdog, EventEmitter);


### PR DESCRIPTION
It is possible to start at creation by calling kick()
but it is not possible to disable auto start in constructor